### PR TITLE
fixed health check on connect service

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ How does the application get it's Vault token?
 
 
 ### Refactor
-- create consul connect tests
+
 
 
 ## Done
@@ -72,3 +72,4 @@ __Secret-ID Factory__
 - Build a new service (Secret-ID Factory) that generates a wrapped secret-id upon receipt of an app-role - (api only)
 - Build this in a separate repository using a similar CI/CD pipeline mentality
 - Added Consul Connect to the Service
+- create consul connect tests

--- a/scripts/install_factory_service.sh
+++ b/scripts/install_factory_service.sh
@@ -10,6 +10,17 @@ register_secret_id_service_with_consul () {
       "service": {
         "name": "approle",
         "port": 8314,
+        "checks": [
+            {
+                "id": "api",
+                "name": "Factory Service SecretID",
+                "http": "http://127.0.0.1:8314/health",
+                "tls_skip_verify": true,
+                "method": "GET",
+                "interval": "10s",
+                "timeout": "1s"
+            }
+        ],
         "connect": { "sidecar_service": {} }
       }
       


### PR DESCRIPTION
# Why is the PR required?

### Issue:

Factory service healthcheck broken

## What does this PR do?

fixed health check on connect service

## How was this PR implemented?

Changed to test service on loopback address

## How long did it take?

5 minutes


